### PR TITLE
PRDResultPage에서 선택한 스타일이 반영되는 문구를 수정함

### DIFF
--- a/app/prd-result/page.tsx
+++ b/app/prd-result/page.tsx
@@ -976,7 +976,7 @@ export default function PRDResultPage() {
                       </div>
                       <div className="text-xs text-[hsl(var(--muted-foreground))] mt-3 px-1 flex items-center gap-2 flex-shrink-0">
                         <div className="w-1.5 h-1.5 rounded-full bg-[hsl(var(--accent))]"></div>
-                        선택한 스타일은 ZIP 다운로드에 theme.css로 포함됩니다.
+                        선택한 스타일은 PRD.md 파일의 디자인 시스템 가이드에 포함됩니다.
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
사진을 '선택한 스타일은 PRD.md 파일의 디자인 시스템 가이드에 포함됩니다.' 로 수정 

<img width="348" height="125" alt="image" src="https://github.com/user-attachments/assets/50ead772-623e-490b-b804-2d6a7ac7704e" />